### PR TITLE
Add verified_at_block_hash for PooledUserOpsByHash response

### DIFF
--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -123,7 +123,7 @@ Bundlers MUST locally store the following `MetaData`:
 ```
 (
   seq_number: uint64
-  supported_mempools: List<mempool_id, MAX_SUPPORTED_MEMPOOLS>
+  supported_mempools: List[MempoolID, MAX_SUPPORTED_MEMPOOLS]
 )
 ```
 

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -107,8 +107,8 @@ This section outlines constants that are used in this spec.
 
 This section outlines type definitions that are used in this spec.
 
-| Name | Value | Description |
-|---|---|---|
+| Name | Description |
+|---|---|
 | `bytes32`    | Fixed lenght array of bytes with length 32|
 | `bytes46`    | Fixed lenght array of bytes with length 46|
 

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -214,9 +214,13 @@ Implementations MUST use a single encoding for gossip. Changing an encoding will
 The metadata associated to each mempool that a bundler supports is documented and stored in IPFS (a copy of this is also suggested to be submitted to [`eth-infinitism`](https://github.com/eth-infinitism) Github repo). 
 
 This [`IPFS CID`](https://docs.ipfs.tech/concepts/content-addressing/) string of the file is called `mempool-id` and this is used as the topic for subscription in the bundlers. 
+The schema for a `MempoolID` is:
 ```
-  mempool_id: List<byte, MAX_IPFS_CID_LENGTH>
+(
+    List[byte, MAX_IPFS_CID_LENGTH]
+)
 ```
+_Note_: This is a UTF-8 encoding of of the IPFS CID string. Clients MUST interpret this byte sequence as a UTF-8 string and MUST reject any invalid byte sequences.
 
 The proposed structure of the mempool metadata is as follows
 

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -114,7 +114,6 @@ This section outlines type definitions that are used in this spec.
 | Name | Description |
 |---|---|
 | `bytes32`    | Fixed length array of bytes with length 32|
-| `bytes46`    | Fixed lenght array of bytes with length 46|
 
 ## MetaData
 

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -106,6 +106,7 @@ This section outlines constants that are used in this spec.
 | `MAX_SUPPORTED_MEMPOOLS`        | `1024`                     | The maximum amount of supported mempools. |
 | `MESSAGE_DOMAIN_INVALID_SNAPPY` | `DomainType('0x00000000')` | 4-byte domain for gossip message-id isolation of *invalid* snappy messages |
 | `MESSAGE_DOMAIN_VALID_SNAPPY`   | `DomainType('0x01000000')` | 4-byte domain for gossip message-id isolation of *valid* snappy messages |(feat(p2p): redefine the gossip message id and contents)
+| `MAX_IPFS_CID_LENGTH`           | `256`                      | The maximum length for the IPFS CID string.|
 
 ## Type Definitions
 
@@ -142,7 +143,10 @@ Topics are plain UTF-8 strings and are encoded on the wire as determined by prot
 Topic strings have form: `/account_abstraction/mempool_id/Name/Encoding`.
 This defines both the type of data being sent on the topic and how the data field of the message is encoded.
 
-- `mempool_id` - the IPFS hash(including the "Qm" prefix) of the file that contains the description of the metadata of the mempool. Please see [mempool-id](#mempool-id) section for further details.
+- `mempool_id` - the IPFS CID string of the file that contains the description of the metadata of the mempool. Please see [mempool-id](#mempool-id) section for further details.
+```
+  mempool_id: List<byte, MAX_IPFS_CID_LENGTH>
+```
 - `Name` - see table below
 - `Encoding` - the encoding strategy describes a specific representation of bytes that will be transmitted over the wire. See the [Encodings](#Encodings) section for further details.
 

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -390,7 +390,7 @@ All messages that contain only a single field MUST be encoded directly as the ty
 Request, Response Content:
 ```
 (
-  List[bytes32,MAX_OPS_PER_REQUEST]
+  List[bytes46,MAX_OPS_PER_REQUEST]
 )
 ```
 The fields are, as seen by the client at the time of sending the message:
@@ -494,7 +494,7 @@ Request Content:
 
 ```
 (
-  mempool: Bytes32
+  mempool: Bytes46
   offset: uint64
 )
 ```

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -113,7 +113,7 @@ This section outlines type definitions that are used in this spec.
 
 | Name | Description |
 |---|---|
-| `bytes32`    | Fixed lenght array of bytes with length 32|
+| `bytes32`    | Fixed length array of bytes with length 32|
 | `bytes46`    | Fixed lenght array of bytes with length 46|
 
 ## MetaData

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -123,7 +123,7 @@ Bundlers MUST locally store the following `MetaData`:
 ```
 (
   seq_number: uint64
-  supported_mempools: List[Bytes32, MAX_SUPPORTED_MEMPOOLS]
+  supported_mempools: List<mempool_id, MAX_SUPPORTED_MEMPOOLS>
 )
 ```
 

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -528,7 +528,7 @@ Request Content:
 Response Content: 
 ```
 (
-  List[UserOp, MAX_OPS_PER_REQUEST]
+  List[PooledUserOp, MAX_OPS_PER_REQUEST]
 )
 ```
 
@@ -614,4 +614,10 @@ class UserOperationsWithEntryPoint(Container):
     verified_at_block_hash: uint256
     chain_id: uint256
     user_operations: List[UserOp, MAX_OPS_PER_REQUEST]
+```
+
+```python
+class PooledUserOp(Container):
+    verified_at_block_hash: uint256
+    user_operation: UserOp
 ```

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -144,9 +144,6 @@ Topic strings have form: `/account_abstraction/mempool_id/Name/Encoding`.
 This defines both the type of data being sent on the topic and how the data field of the message is encoded.
 
 - `mempool_id` - the IPFS CID string of the file that contains the description of the metadata of the mempool. Please see [mempool-id](#mempool-id) section for further details.
-```
-  mempool_id: List<byte, MAX_IPFS_CID_LENGTH>
-```
 - `Name` - see table below
 - `Encoding` - the encoding strategy describes a specific representation of bytes that will be transmitted over the wire. See the [Encodings](#Encodings) section for further details.
 
@@ -205,14 +202,21 @@ Upon receiving a user operation from an `eth_sendUserOperation` RPC call, a bund
 
 Topics are post-fixed with an encoding. Encodings define how the payload of a gossipsub message is encoded.
 
-ssz_snappy - All objects are SSZ-encoded and then compressed with Snappy block compression. Example: The `user_operations` topic string of the canonical mempool is /account_abstraction/<mempool_id>/user_operations/ssz_snappy, the <mempool_id> is `TBD` (the IPFS hash of the mempool yaml/JSON file) and the data field of a gossipsub message is a UserOpsWithEntryPoint that has been SSZ-encoded and then compressed with Snappy.
+ssz_snappy - All objects are SSZ-encoded and then compressed with Snappy block compression. Example: The `user_operations` topic string of the canonical mempool is /account_abstraction/<mempool_id>/user_operations/ssz_snappy, the <mempool_id> is `TBD` (the IPFS CID string of the mempool yaml/JSON file) and the data field of a gossipsub message is a UserOpsWithEntryPoint that has been SSZ-encoded and then compressed with Snappy.
 Snappy has two formats: "block" and "frames" (streaming). Gossip messages remain relatively small (100s of bytes to 100s of kilobytes) so basic Snappy block compression is used to avoid the additional overhead associated with Snappy frames.
 
 Implementations MUST use a single encoding for gossip. Changing an encoding will require coordination between participating implementations.
 
 ### Mempool ID
 
-The metadata associated to each mempool that a bundler supports is documented and stored in IPFS (a copy of this is also suggested to be submitted to [`eth-infinitism`](https://github.com/eth-infinitism) Github repo). This IPFS hash of the file is called `mempool-id` and this is used as the topic for subscription in the bundlers. The proposed structure of the mempool metadata is as follows
+The metadata associated to each mempool that a bundler supports is documented and stored in IPFS (a copy of this is also suggested to be submitted to [`eth-infinitism`](https://github.com/eth-infinitism) Github repo). 
+
+This [`IPFS CID`](https://docs.ipfs.tech/concepts/content-addressing/) string of the file is called `mempool-id` and this is used as the topic for subscription in the bundlers. 
+```
+  mempool_id: List<byte, MAX_IPFS_CID_LENGTH>
+```
+
+The proposed structure of the mempool metadata is as follows
 
 ```yaml
 chainId: '1'
@@ -222,7 +226,7 @@ description: >-
   Ethereum Mainnnet
 minimumStake: '0.0'
 ```
-The `mempool-id` of the canonical mempool is `TBD` (IPFS hash of the yaml/JSON file).
+The `mempool-id` of the canonical mempool is `TBD` (IPFS CID string of the yaml/JSON file).
 
 #### Canonical Mempools
 

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -103,6 +103,14 @@ This section outlines constants that are used in this spec.
 | `RESP_TIMEOUT`	     | `10s` | The maximum time for complete response transfer. |
 | `TTFB_TIMEOUT`       | `5s` | The maximum time to wait for first byte of request response (time-to-first-byte). |
 
+## Type Definitions
+
+This section outlines type definitions that are used in this spec.
+
+| Name | Value | Description |
+|---|---|---|
+| `bytes32`    | Fixed lenght array of bytes with length 32|
+| `bytes46`    | Fixed lenght array of bytes with length 46|
 
 ## MetaData
 
@@ -133,7 +141,7 @@ Topics are plain UTF-8 strings and are encoded on the wire as determined by prot
 Topic strings have form: `/account_abstraction/mempool_id/Name/Encoding`.
 This defines both the type of data being sent on the topic and how the data field of the message is encoded.
 
-- `mempool_id` - the lower case IPFS hash of the file that contains the description of the metadata of the mempool. Please see [mempool-id](#mempool-id) section for further details.
+- `mempool_id` - the IPFS hash(including the "Qm" prefix) of the file that contains the description of the metadata of the mempool. Please see [mempool-id](#mempool-id) section for further details.
 - `Name` - see table below
 - `Encoding` - the encoding strategy describes a specific representation of bytes that will be transmitted over the wire. See the [Encodings](#Encodings) section for further details.
 
@@ -395,7 +403,7 @@ Request, Response Content:
 ```
 The fields are, as seen by the client at the time of sending the message:
 
-- supported_mempools - List of supported mempools.
+- supported_mempools - List of the ascii encoding of the IPFS hash(including the "Qm" prefix) for the supported mempools, the ascii encoding of the ipfs hash has a fixed length of 46 bytes.
 
 The dialing client MUST send a `Status` request upon connection.
 
@@ -494,7 +502,7 @@ Request Content:
 
 ```
 (
-  mempool: Bytes46
+  mempool: bytes46
   offset: uint64
 )
 ```
@@ -503,11 +511,11 @@ Response Content:
 ```
 (
   more_flag: uint64
-  hashes: List[Bytes32, MAX_OPS_PER_REQUEST]
+  hashes: List[bytes32, MAX_OPS_PER_REQUEST]
 )
 ```
 
-The `pooled_user_ops_by_hash` requests UserOp mempool of all connected peers as soon as bundler node starts up. The node requests UserOps from the recipients mempool for a given `mempool_id` and `offset`. The `offset` is set to `0` for the initial call. The recommended soft limit for PooledUserOpHashes requests is `MAX_OPS_PER_REQUEST` hashes. The recipient may enforce an arbitrary limit on the response (size or serving time), which must not be considered a protocol violation. The `more_flag` is set to 0, if the connected peer's reported hashes is <= to `MAX_OPS_PER_REQUEST`. Otherwise the `more_flag` is set to a value > 0. The value of `more_flag` can be used to determine the number of subsequent req/resp a node has to perform to refetch the missing hashes from the connected peer.
+The `pooled_user_ops_by_hash` requests UserOp mempool of all connected peers as soon as bundler node starts up. The node requests UserOps from the recipients mempool for a given `mempool` and `offset`. The `mempool` is the ascii encoding of the IPFS hash(including the "Qm" prefix) for the mempool, the ascii encoding of the ipfs hash has a fixed length of 46 bytes. The `offset` is set to `0` for the initial call. The recommended soft limit for PooledUserOpHashes requests is `MAX_OPS_PER_REQUEST` hashes. The recipient may enforce an arbitrary limit on the response (size or serving time), which must not be considered a protocol violation. The `more_flag` is set to 0, if the connected peer's reported hashes is <= to `MAX_OPS_PER_REQUEST`. Otherwise the `more_flag` is set to a value > 0. The value of `more_flag` can be used to determine the number of subsequent req/resp a node has to perform to refetch the missing hashes from the connected peer.
 
 The request/response MUST be encoded as a single SSZ-field.
 

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -421,7 +421,6 @@ Request, Response Content:
 ```
 The fields are, as seen by the client at the time of sending the message:
 
-
 - chain_id - Chain ID of the bundler's network. For a community curated list of chain IDs, see https://chainid.network.
 - block_hash - Last block hash seen by the bundler.
 - block_number - Last block number seen by the bundler.
@@ -575,7 +574,7 @@ Request Content:
 Response Content: 
 ```
 (
-  List[PooledUserOp, MAX_OPS_PER_REQUEST]
+  List[VerifiedUserOperation, MAX_OPS_PER_REQUEST]
 )
 ```
 
@@ -657,10 +656,4 @@ class VerifiedUserOperation(Container):
     user_operation: UserOp
     entry_point: Address
     verified_at_block_hash: uint256
-```
-
-```python
-class PooledUserOp(Container):
-    verified_at_block_hash: uint256
-    user_operation: UserOp
 ```

--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -591,7 +591,7 @@ Response Content:
 )
 ```
 
-The `pooled_user_ops_by_hash` requests UserOps from the recipients UserOp mempool for a given EntryPoint contract address. The recommended soft limit for PooledUserOpsByHash requests is MAX_OPS_PER_REQUEST hashes. The recipient may enforce an arbitrary limit on the response (size or serving time), which must not be considered a protocol violation.
+The `pooled_user_ops_by_hash` requests UserOps from the recipients UserOp mempool for a given list of user operations hashes. The recommended soft limit for PooledUserOpsByHash requests is MAX_OPS_PER_REQUEST hashes. The recipient may enforce an arbitrary limit on the response (size or serving time), which must not be considered a protocol violation.
 
 The request MUST be encoded as a single SSZ-field.
 


### PR DESCRIPTION
- Add verified_at_block_hash for PooledUserOpsByHash response
- Change mempool hash data type as IPFS hash length + Qm prefix is 46 bytes