### PR TITLE
fix: add entrypoint to debug_bundler_addUserOps

### DIFF
--- a/src/debug/debug.yaml
+++ b/src/debug/debug.yaml
@@ -70,6 +70,10 @@
         type: array
         items:
           $ref: '#/components/schemas/UserOperation'
+    - name: entryPoint
+      required: true
+      schema:
+        $ref: '#/components/schemas/address'
   result:
     name: ok
     schema:


### PR DESCRIPTION
RPC endpoint `debug_bundler_addUserOps` is missing param `entryPoint`

`dump_mempool`, `set_reputation`, and `dump_reputation` all have param `entryPoint` 